### PR TITLE
feat: add visual agent for image generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,14 +16,27 @@ st.title("🎓 Edu-Global AI Agent")
 
 if "history" not in st.session_state:
     st.session_state.history = []
+if "visuals" not in st.session_state:
+    st.session_state.visuals = []
 
 user_input = st.chat_input("Nhập câu hỏi…")
 if user_input:
     st.session_state.history.append(HumanMessage(content=user_input))
     with st.spinner("Đang suy nghĩ…"):
-        out = asyncio.run(graph.ainvoke({"messages": st.session_state.history}))
+        out = asyncio.run(
+            graph.ainvoke(
+                {
+                    "messages": st.session_state.history,
+                    "visuals": st.session_state.visuals,
+                }
+            )
+        )
         st.session_state.history = out["messages"]  # ✅ không được thụt lề lệch
+        st.session_state.visuals = out.get("visuals", [])
 
 for m in st.session_state.history:
     role = "👤" if m.type == "human" else "🤖"
     st.markdown(f"**{role}**: {m.content}")
+
+for img in st.session_state.visuals:
+    st.image(img)

--- a/src/eduagent/graph.py
+++ b/src/eduagent/graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import os
 from dotenv import load_dotenv
 from typing import TypedDict, Annotated, List, Union
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from langchain_core.runnables import RunnableConfig
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
@@ -13,17 +13,22 @@ load_dotenv()  # đảm bảo đọc OPENAI_API_KEY sớm
 
 # ✨ Thêm OpenAI
 from langchain_openai import ChatOpenAI
+from openai import OpenAI
+
 
 # === Reducer đúng chuẩn ===
 def last_5_msgs(a: List[BaseMessage], b: List[BaseMessage]) -> List[BaseMessage]:
     return (a + b)[-5:]
 
+
 @dataclass
 class State:
     messages: Annotated[List[BaseMessage], last_5_msgs]
+    visuals: List[str] = field(default_factory=list)
 
 
 # === Agent Nodes ===
+
 
 def planner_agent(state: State, config: RunnableConfig) -> dict:
     print("🔍 [Planner Agent] Suy nghĩ kế hoạch...")
@@ -33,6 +38,10 @@ def planner_agent(state: State, config: RunnableConfig) -> dict:
 
 # ✨ Gọi LLM thực tế từ OpenAI
 llm = ChatOpenAI(model_name="gpt-4.1", temperature=0.7)
+
+# Client tạo ảnh từ OpenAI
+img_client = OpenAI()
+
 
 def teacher_agent(state: State, config: RunnableConfig) -> dict:
     """Gọi GPT-4 để trả lời kiến thức cho giáo viên / học sinh."""
@@ -47,9 +56,29 @@ def teacher_agent(state: State, config: RunnableConfig) -> dict:
     return {"messages": state.messages + [response]}
 
 
+def visual_agent(state: State, config: RunnableConfig) -> dict:
+    """Tạo hình minh họa dựa trên lời nhắc gần nhất."""
+    print("🖼️ [Visual Agent] Tạo hình minh họa...")
+
+    prompt = state.messages[-1].content if state.messages else ""
+    visuals = state.visuals
+    try:
+        result = img_client.images.generate(model="gpt-image-1", prompt=prompt)
+        b64_img = result.data[0].b64_json
+        visuals = visuals + [f"data:image/png;base64,{b64_img}"]
+        msg = AIMessage(content="Đây là hình minh họa cho câu hỏi của bạn.")
+    except Exception as e:
+        print("❌ [Visual Agent] Lỗi tạo ảnh:", e)
+        msg = AIMessage(content="Xin lỗi, tôi không thể tạo hình minh họa lúc này.")
+
+    return {"messages": state.messages + [msg], "visuals": visuals}
+
+
 def parent_coach_agent(state: State, config: RunnableConfig) -> dict:
     print("👨‍👩‍👧 [Parent Coach Agent] Gợi ý cho phụ huynh...")
-    msg = AIMessage(content="Gợi ý: hãy cùng con luyện tập 15 phút mỗi ngày và hỏi con xem con hiểu bài chưa.")
+    msg = AIMessage(
+        content="Gợi ý: hãy cùng con luyện tập 15 phút mỗi ngày và hỏi con xem con hiểu bài chưa."
+    )
     return {"messages": state.messages + [msg]}
 
 
@@ -61,7 +90,7 @@ def rag_agent(state: State, config: RunnableConfig) -> dict:
 
 def finish(state: State, config: RunnableConfig) -> dict:
     print("✅ [End] Kết thúc phiên trả lời.")
-    return {"messages": state.messages}
+    return {"messages": state.messages, "visuals": state.visuals}
 
 
 # === Build Graph ===
@@ -69,13 +98,15 @@ def finish(state: State, config: RunnableConfig) -> dict:
 graph = StateGraph(State)
 
 graph.add_node("planner", planner_agent)
+graph.add_node("visual", visual_agent)
 graph.add_node("teacher", teacher_agent)
 graph.add_node("parent", parent_coach_agent)
 graph.add_node("rag", rag_agent)
 graph.add_node("end", finish)
 
 graph.set_entry_point("planner")
-graph.add_edge("planner", "teacher")
+graph.add_edge("planner", "visual")
+graph.add_edge("visual", "teacher")
 graph.add_edge("teacher", "rag")
 graph.add_edge("rag", "parent")
 graph.add_edge("parent", "end")


### PR DESCRIPTION
## Summary
- add `visual_agent` using OpenAI image API and track visuals in state
- connect new visual node in `StateGraph` and expose images in output
- display generated images in Streamlit app via `st.image`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agent')*

------
https://chatgpt.com/codex/tasks/task_e_688fb097f78c833188928a308316dc20