### PR TITLE
feat: add planner branching

### DIFF
--- a/src/eduagent/graph.py
+++ b/src/eduagent/graph.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
-import os
 from dotenv import load_dotenv
-from typing import TypedDict, Annotated, List, Union
+from typing import Annotated, List, Optional
 from dataclasses import dataclass
 
 from langchain_core.runnables import RunnableConfig
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
-from langgraph.graph import StateGraph, END
+from langgraph.graph import StateGraph
 
 load_dotenv()  # đảm bảo đọc OPENAI_API_KEY sớm
 
@@ -21,14 +20,39 @@ def last_5_msgs(a: List[BaseMessage], b: List[BaseMessage]) -> List[BaseMessage]
 @dataclass
 class State:
     messages: Annotated[List[BaseMessage], last_5_msgs]
+    next_agent: Optional[str] = None
 
 
 # === Agent Nodes ===
 
 def planner_agent(state: State, config: RunnableConfig) -> dict:
+    """Sử dụng LLM để suy luận bước tiếp theo và chọn agent phù hợp."""
     print("🔍 [Planner Agent] Suy nghĩ kế hoạch...")
-    msg = AIMessage(content="Tôi đã hiểu yêu cầu. Để tôi lên kế hoạch cho bạn.")
-    return {"messages": state.messages + [msg]}
+
+    planning_prompt = state.messages + [
+        HumanMessage(
+            content=(
+                "Dựa vào hội thoại trên, hãy lên kế hoạch bước tiếp theo cho hệ thống. "
+                "Chọn một trong các agent sau để xử lý: visual, teacher, rag. "
+                "Trả lời duy nhất bằng JSON với hai khóa 'plan' và 'next_agent'."
+            )
+        )
+    ]
+
+    response = llm.invoke(planning_prompt)
+
+    try:
+        import json
+
+        parsed = json.loads(response.content)
+        plan_text = parsed.get("plan", "")
+        next_agent = parsed.get("next_agent", "teacher")
+    except Exception:
+        plan_text = response.content
+        next_agent = "teacher"
+
+    msg = AIMessage(content=plan_text)
+    return {"messages": state.messages + [msg], "next_agent": next_agent}
 
 
 # ✨ Gọi LLM thực tế từ OpenAI
@@ -47,9 +71,9 @@ def teacher_agent(state: State, config: RunnableConfig) -> dict:
     return {"messages": state.messages + [response]}
 
 
-def parent_coach_agent(state: State, config: RunnableConfig) -> dict:
-    print("👨‍👩‍👧 [Parent Coach Agent] Gợi ý cho phụ huynh...")
-    msg = AIMessage(content="Gợi ý: hãy cùng con luyện tập 15 phút mỗi ngày và hỏi con xem con hiểu bài chưa.")
+def visual_agent(state: State, config: RunnableConfig) -> dict:
+    print("🖼️ [Visual Agent] Tạo nội dung trực quan...")
+    msg = AIMessage(content="Đây là nội dung trực quan cho yêu cầu của bạn.")
     return {"messages": state.messages + [msg]}
 
 
@@ -70,14 +94,22 @@ graph = StateGraph(State)
 
 graph.add_node("planner", planner_agent)
 graph.add_node("teacher", teacher_agent)
-graph.add_node("parent", parent_coach_agent)
+graph.add_node("visual", visual_agent)
 graph.add_node("rag", rag_agent)
 graph.add_node("end", finish)
 
 graph.set_entry_point("planner")
-graph.add_edge("planner", "teacher")
-graph.add_edge("teacher", "rag")
-graph.add_edge("rag", "parent")
-graph.add_edge("parent", "end")
+graph.add_conditional_edges(
+    "planner",
+    lambda state: state.next_agent,
+    {
+        "teacher": "teacher",
+        "visual": "visual",
+        "rag": "rag",
+    },
+)
+graph.add_edge("teacher", "end")
+graph.add_edge("visual", "end")
+graph.add_edge("rag", "end")
 
 graph = graph.compile()


### PR DESCRIPTION
## Summary
- let planner agent decide next agent via LLM plan
- add visual agent and branch to teacher, visual, or RAG

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'agent.graph')*

------
https://chatgpt.com/codex/tasks/task_e_688fb0ea07f88331ac4904b25c122b05